### PR TITLE
Correct gRPC dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# th2-read-db 0.3.0
+# th2-read-db 0.3.2
 
 The read-db is a component for extracting data from databases using JDBC technology. If database has JDBC driver the read can work with the database
 
@@ -176,6 +176,12 @@ spec:
 ```
 
 ## Changes
+
+### 0.3.2
+
+#### Changed:
+
++ remove redundant dependencies from gRPC
 
 ### 0.3.0
 

--- a/app/gradle.properties
+++ b/app/gradle.properties
@@ -1,3 +1,3 @@
 kotlin.code.style=official
-release_version=0.3.1
+release_version=0.3.2
 description=read-db component for extracting data from databases using JDBC technology

--- a/core/gradle.properties
+++ b/core/gradle.properties
@@ -1,3 +1,3 @@
 kotlin.code.style=official
-release_version=0.3.1
+release_version=0.3.2
 description=core part of read db to create an application with required JDBC drivers in the classpath

--- a/grpc/build.gradle
+++ b/grpc/build.gradle
@@ -18,7 +18,7 @@ sourceCompatibility = 11
 targetCompatibility = 11
 
 ext {
-    grpcVersion         = '1.58.0'
+    grpcVersion         = '1.56.0'
     protobufVersion     = '3.24.3' // The protoc:3.23.3 https://github.com/protocolbuffers/protobuf/issues/13070
     serviceGeneratorVersion = '3.4.0'
     grpcCommonVersion = '4.3.0-dev'

--- a/grpc/gradle.properties
+++ b/grpc/gradle.properties
@@ -1,3 +1,3 @@
 kotlin.code.style=official
-release_version=0.0.2
+release_version=0.0.3
 description=gRPC API for executing requests in read-db application

--- a/grpc/package_info.json
+++ b/grpc/package_info.json
@@ -1,4 +1,4 @@
 {
     "package_name": "th2_grpc_read_db",
-    "package_version": "0.0.1"
+    "package_version": "0.0.3"
 }

--- a/grpc/requirements.txt
+++ b/grpc/requirements.txt
@@ -12,6 +12,5 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-
-th2-grpc-common>=3,<4
-mypy-protobuf==3.2
+grpcio-tools==1.56.0
+mypy-protobuf==3.4

--- a/grpc/setup.py
+++ b/grpc/setup.py
@@ -120,7 +120,8 @@ setup(
     license='Apache License 2.0',
     python_requires='>=3.7',
     install_requires=[
-        'th2-grpc-common>=3,<4'
+        'grpcio-tools==1.56.0',
+        'mypy-protobuf==3.4'
     ],
     packages=packages,
     package_data=package_data,


### PR DESCRIPTION
gRPC dependencies had redundant libraries that are not required for read-db work. They were removed