### PR TITLE
[th2-5149] Read-db should create event with query details, unique query id and start/end times when user execute query

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ The list of queries that can be executed by read-db.
   It might contain parameters in the following format: `${<name>[:<type>]}`.
   The **type** part can be omitted if the type is `varchar`.
   Examples: `${id:integer}`, `${registration_time:timestamp}`, `${first_name}`
+  [Types](https://docs.oracle.com/javase/8/docs/api/java/sql/JDBCType.html): bit, tinyint, smallint, integer, bigint, float, real, double, numeric, decimal, char, varchar, longvarchar, date, time, timestamp, binary, varbinary, longvarbinary, null, other, java_object, distinct, struct, array, blob, clob, ref, datalink, boolean, rowid, nchar, nvarchar, longnvarchar, nclob, sqlxml, ref_cursor, time_with_timezone, timestamp_with_timezone
 + defaultParameters - the default values for parameters. They will be used if the parameter was not specified in the request
 + messageType - the message type that should be associated with this query.
   If it is set the read-db will set a property `th2.csv.override_message_type` with specified value
@@ -343,6 +344,10 @@ spec:
 #### Feature:
 
 + gRPC execute method generates unique id for each execution and puts it into related event and messages.
+
+#### Fix:
+
++ gRPC Execute method doesn't respond rows with null values. gRPC server implementation skips columns with null value after fix.
 
 ### 0.6.0
 

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ metadata:
   name: read-db
 spec:
   image-name: ghcr.io/th2-net/th2-read-db
-  image-version: 0.0.1
+  image-version: 0.7.0-dev
   type: th2-read
   custom-config:
     dataSources:
@@ -261,7 +261,7 @@ metadata:
   name: read-db
 spec:
   imageName: ghcr.io/th2-net/th2-read-db
-  imageVersion: 0.0.1
+  imageVersion: 0.7.0-dev
   type: th2-read
   customConfig:
     dataSources:
@@ -335,6 +335,9 @@ spec:
         memory: 100Mi
         cpu: 50m
 ```
+
+### Oracle redo logs
+[How to configure th2-read-db to pull data from redo log](oracle-log-miner.md)
 
 ## Changes
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,6 @@ publication:
   maxDelayMillis: 1000
   maxBatchSize: 100
 eventPublication:
-  maxBatchSizeInBytes: 1048576
   maxBatchSizeInItems: 100
   maxFlushTime: 1000
 ```
@@ -223,7 +222,6 @@ spec:
       maxDelayMillis: 1000
       maxBatchSize: 100
     eventPublication:
-      maxBatchSizeInBytes: 1048576
       maxBatchSizeInItems: 100
       maxFlushTime: 1000
     useTransport: true
@@ -301,7 +299,6 @@ spec:
       maxDelayMillis: 1000
       maxBatchSize: 100
     eventPublication:
-      maxBatchSizeInBytes: 1048576
       maxBatchSizeInItems: 100
       maxFlushTime: 1000
     useTransport: true

--- a/app/gradle.properties
+++ b/app/gradle.properties
@@ -1,3 +1,3 @@
 kotlin.code.style=official
-release_version=0.6.0
+release_version=0.7.0
 description=read-db component for extracting data from databases using JDBC technology

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -69,6 +69,8 @@ dependencies {
     testImplementation "org.testcontainers:oracle-xe"
     testImplementation "io.grpc:grpc-testing"
 
+    testImplementation 'com.exactpro.th2:junit-jupiter-integration:0.0.1-master-6956603819-5241ee5-SNAPSHOT'
+
     testRuntimeOnly("com.mysql:mysql-connector-j:8.1.0") {
         because("mysql support")
     }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -58,6 +58,7 @@ dependencies {
     implementation "com.fasterxml.jackson.core:jackson-databind"
 
     testImplementation "org.junit.jupiter:junit-jupiter:5.10.0"
+    testImplementation "org.jetbrains.kotlin:kotlin-test-junit"
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutines_version"
     testImplementation "org.mockito.kotlin:mockito-kotlin:5.1.0"
     testImplementation "io.strikt:strikt-core:0.34.1"
@@ -66,6 +67,7 @@ dependencies {
     testImplementation "org.testcontainers:testcontainers"
     testImplementation "org.testcontainers:mysql"
     testImplementation "org.testcontainers:oracle-xe"
+    testImplementation "io.grpc:grpc-testing"
 
     testRuntimeOnly("com.mysql:mysql-connector-j:8.1.0") {
         because("mysql support")

--- a/core/gradle.properties
+++ b/core/gradle.properties
@@ -1,3 +1,3 @@
 kotlin.code.style=official
-release_version=0.6.0
+release_version=0.7.0
 description=core part of read db to create an application with required JDBC drivers in the classpath

--- a/core/src/main/kotlin/com/exactpro/th2/read/db/app/DataBaseReader.kt
+++ b/core/src/main/kotlin/com/exactpro/th2/read/db/app/DataBaseReader.kt
@@ -97,16 +97,21 @@ class DataBaseReader(
     ) {
         scope.launch {
             with(request) {
-                dataBaseService.executeQuery(sourceId, before, queryId, after, parameters)
-                    .onCompletion {
-                        if (it == null) {
-                            listener.onComplete()
-                        } else {
-                            listener.onError(it)
+                try {
+                    dataBaseService.executeQuery(sourceId, before, queryId, after, parameters)
+                        .onCompletion {
+                            if (it == null) {
+                                listener.onComplete()
+                            } else {
+                                listener.onError(it)
+                            }
+                        }.collect {
+                            rowTransformer(it).transferTo(sourceId, listener, rowListener)
                         }
-                    }.collect {
-                        rowTransformer(it).transferTo(sourceId, listener, rowListener)
-                    }
+                } catch (ex: Exception) {
+                    LOGGER.error(ex) { "cannot execute query '${request.queryId}' for '${request.sourceId}'" }
+                    listener.onError(ex)
+                }
             }
         }
     }

--- a/core/src/main/kotlin/com/exactpro/th2/read/db/app/DataBaseReaderConfiguration.kt
+++ b/core/src/main/kotlin/com/exactpro/th2/read/db/app/DataBaseReaderConfiguration.kt
@@ -31,6 +31,7 @@ class DataBaseReaderConfiguration(
     val queries: Map<QueryId, QueryConfiguration>,
     val startupTasks: List<StartupTaskConfiguration> = emptyList(),
     val publication: PublicationConfiguration = PublicationConfiguration(),
+    val eventPublication: EventPublicationConfiguration = EventPublicationConfiguration(),
     val useTransport: Boolean = false
 )
 
@@ -38,6 +39,12 @@ class PublicationConfiguration(
     val queueSize: Int = 1000,
     val maxDelayMillis: Long = 1000,
     val maxBatchSize: Int = 100,
+)
+
+class EventPublicationConfiguration(
+    val maxBatchSizeInBytes: Long = 1_024 * 1_024,
+    val maxBatchSizeInItems: Int = 100,
+    val maxFlushTime: Long = 1000,
 )
 
 @JsonTypeInfo(

--- a/core/src/main/kotlin/com/exactpro/th2/read/db/app/DataBaseReaderConfiguration.kt
+++ b/core/src/main/kotlin/com/exactpro/th2/read/db/app/DataBaseReaderConfiguration.kt
@@ -42,7 +42,6 @@ class PublicationConfiguration(
 )
 
 class EventPublicationConfiguration(
-    val maxBatchSizeInBytes: Long = 1_024 * 1_024,
     val maxBatchSizeInItems: Int = 100,
     val maxFlushTime: Long = 1000,
 )

--- a/core/src/main/kotlin/com/exactpro/th2/read/db/app/Requests.kt
+++ b/core/src/main/kotlin/com/exactpro/th2/read/db/app/Requests.kt
@@ -19,14 +19,16 @@ package com.exactpro.th2.read.db.app
 import com.exactpro.th2.read.db.core.DataSourceId
 import com.exactpro.th2.read.db.core.QueryId
 import com.exactpro.th2.read.db.core.QueryParametersValues
+import com.fasterxml.jackson.annotation.JsonInclude
 import java.time.Duration
 
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 class ExecuteQueryRequest(
     val sourceId: DataSourceId,
-    val before: List<QueryId>,
+    val before: List<QueryId> = emptyList(),
     val queryId: QueryId,
-    val after: List<QueryId>,
-    val parameters: QueryParametersValues,
+    val after: List<QueryId> = emptyList(),
+    val parameters: QueryParametersValues = emptyMap(),
 )
 
 class PullTableRequest(

--- a/core/src/main/kotlin/com/exactpro/th2/read/db/bootstrap/Main.kt
+++ b/core/src/main/kotlin/com/exactpro/th2/read/db/bootstrap/Main.kt
@@ -184,11 +184,13 @@ internal fun setupApp(
 
     val handler = DataBaseReaderGrpcServer(
         reader,
-        rootEventId,
         { cfg.dataSources[it] ?: error("'$it' data source isn't found in custom config") },
         { cfg.queries[it] ?: error("'$it' query isn't found in custom config") },
-        eventBatcher::onEvent
-    )
+    ) { event, parentEventId ->
+        eventBatcher.onEvent(
+            event.toProto(parentEventId ?: rootEventId)
+        )
+    }
 
     val server = factory.grpcRouter.startServer(handler)
         .start()

--- a/core/src/main/kotlin/com/exactpro/th2/read/db/bootstrap/Utils.kt
+++ b/core/src/main/kotlin/com/exactpro/th2/read/db/bootstrap/Utils.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Exactpro (Exactpro Systems Limited)
+ * Copyright 2023-2024 Exactpro (Exactpro Systems Limited)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -74,10 +74,6 @@ internal fun TableRow.toTransportMessage(dataSourceId: DataSourceId, properties:
     return builder
 }
 
-internal fun TableRow.toMap(): Map<String, String?> {
-    return columns.mapValues { it.value?.toStringValue() }
-}
-
 internal fun TableRow.toCsvBody(): ByteArray {
     return ByteArrayOutputStream().use {
         CSVWriterBuilder(it.writer())
@@ -132,7 +128,7 @@ internal fun MessageSearchResponse.toTableRow(): TableRow {
     }
 }
 
-private fun Any.toStringValue(): String = when (this) {
+internal fun Any.toStringValue(): String = when (this) {
     is BigDecimal -> stripTrailingZeros().toPlainString()
     is Double -> toBigDecimal().toStringValue()
     is Float -> toBigDecimal().toStringValue()

--- a/core/src/main/kotlin/com/exactpro/th2/read/db/bootstrap/Utils.kt
+++ b/core/src/main/kotlin/com/exactpro/th2/read/db/bootstrap/Utils.kt
@@ -38,6 +38,7 @@ import java.math.BigDecimal
 import com.exactpro.th2.common.grpc.RawMessage as ProtoRawMessage
 
 internal const val TH2_CSV_OVERRIDE_MESSAGE_TYPE_PROPERTY = "th2.csv.override_message_type"
+private const val TH2_READ_DB_UNIQUE_ID = "th2.read-db.execute.uid"
 private const val SEPARATOR = ','
 
 internal fun TableRow.toProtoMessage(dataSourceId: DataSourceId, properties: Map<String, String>): ProtoRawMessage.Builder {
@@ -65,9 +66,16 @@ internal fun TableRow.toTransportMessage(dataSourceId: DataSourceId, properties:
     if (associatedMessageType != null) {
         builder.addMetadataProperty(TH2_CSV_OVERRIDE_MESSAGE_TYPE_PROPERTY, associatedMessageType)
     }
+    if (executionId != null) {
+        builder.addMetadataProperty(TH2_READ_DB_UNIQUE_ID, executionId.toString())
+    }
     properties.forEach(builder::addMetadataProperty)
 
     return builder
+}
+
+internal fun TableRow.toMap(): Map<String, String?> {
+    return columns.mapValues { it.value?.toStringValue() }
 }
 
 internal fun TableRow.toCsvBody(): ByteArray {

--- a/core/src/main/kotlin/com/exactpro/th2/read/db/core/DataSourceConfiguration.kt
+++ b/core/src/main/kotlin/com/exactpro/th2/read/db/core/DataSourceConfiguration.kt
@@ -16,9 +16,14 @@
 
 package com.exactpro.th2.read.db.core
 
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.annotation.JsonProperty
+
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 data class DataSourceConfiguration(
     val url: String,
     val username: String? = null,
+    @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
     val password: String? = null,
     val properties: Map<String, String> = emptyMap(),
 )

--- a/core/src/main/kotlin/com/exactpro/th2/read/db/core/Model.kt
+++ b/core/src/main/kotlin/com/exactpro/th2/read/db/core/Model.kt
@@ -16,16 +16,22 @@
 
 package com.exactpro.th2.read.db.core
 
+import com.fasterxml.jackson.core.JsonGenerator
 import com.fasterxml.jackson.databind.DeserializationContext
+import com.fasterxml.jackson.databind.SerializerProvider
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
+import com.fasterxml.jackson.databind.annotation.JsonSerialize
 import com.fasterxml.jackson.databind.deser.std.FromStringDeserializer
+import com.fasterxml.jackson.databind.ser.std.StdSerializer
 
 typealias QueryParametersValues = Map<String, Collection<String>>
 
 @JsonDeserialize(using = DataSourceIdDeserializer::class)
+@JsonSerialize(using = DataSourceIdSerializer::class)
 data class DataSourceId(val id: String)
 
 @JsonDeserialize(using = QueryIdDeserializer::class)
+@JsonSerialize(using = QueryIdSerializer::class)
 data class QueryId(val id: String)
 
 data class TaskId(val id: String)
@@ -40,6 +46,16 @@ private class DataSourceIdDeserializer : FromStringDeserializer<DataSourceId>(Da
     override fun _deserialize(value: String, ctxt: DeserializationContext?): DataSourceId = DataSourceId(value)
 }
 
+private class DataSourceIdSerializer : StdSerializer<DataSourceId>(DataSourceId::class.java) {
+    override fun serialize(value: DataSourceId, gen: JsonGenerator, provider: SerializerProvider) =
+        gen.writeString(value.id)
+}
+
 private class QueryIdDeserializer : FromStringDeserializer<QueryId>(QueryId::class.java) {
     override fun _deserialize(value: String, ctxt: DeserializationContext?): QueryId = QueryId(value)
+}
+
+private class QueryIdSerializer : StdSerializer<QueryId>(QueryId::class.java) {
+    override fun serialize(value: QueryId, gen: JsonGenerator, provider: SerializerProvider) =
+        gen.writeString(value.id)
 }

--- a/core/src/main/kotlin/com/exactpro/th2/read/db/core/Model.kt
+++ b/core/src/main/kotlin/com/exactpro/th2/read/db/core/Model.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Exactpro (Exactpro Systems Limited)
+ * Copyright 2022-2023 Exactpro (Exactpro Systems Limited)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,7 +30,11 @@ data class QueryId(val id: String)
 
 data class TaskId(val id: String)
 
-data class TableRow(val columns: Map<String, Any?>, val associatedMessageType: String? = null)
+data class TableRow(
+    val columns: Map<String, Any?>,
+    val associatedMessageType: String? = null,
+    val executionId: Long? = null
+)
 
 private class DataSourceIdDeserializer : FromStringDeserializer<DataSourceId>(DataSourceId::class.java) {
     override fun _deserialize(value: String, ctxt: DeserializationContext?): DataSourceId = DataSourceId(value)

--- a/core/src/main/kotlin/com/exactpro/th2/read/db/core/impl/DataBaseServiceImpl.kt
+++ b/core/src/main/kotlin/com/exactpro/th2/read/db/core/impl/DataBaseServiceImpl.kt
@@ -101,9 +101,9 @@ class DataBaseServiceImpl(
                         )
                     }
                 }
-
-                LOGGER.trace { "Closing connection to $dataSourceId" }
+                LOGGER.info { "Query $queryId for $dataSourceId connection was executed" }
             } finally {
+                LOGGER.trace { "Closing connection to $dataSourceId" }
                 runCatching { connection.close() }.onFailure { LOGGER.error(it) { "cannot close connection for $dataSourceId" } }
             }
         }

--- a/core/src/main/kotlin/com/exactpro/th2/read/db/impl/grpc/DataBaseReaderGrpcServer.kt
+++ b/core/src/main/kotlin/com/exactpro/th2/read/db/impl/grpc/DataBaseReaderGrpcServer.kt
@@ -23,7 +23,7 @@ import com.exactpro.th2.common.message.toJson
 import com.exactpro.th2.read.db.app.DataBaseReader
 import com.exactpro.th2.read.db.app.ExecuteQueryRequest
 import com.exactpro.th2.read.db.app.PullTableRequest
-import com.exactpro.th2.read.db.bootstrap.toMap
+import com.exactpro.th2.read.db.bootstrap.toStringValue
 import com.exactpro.th2.read.db.core.DataSourceConfiguration
 import com.exactpro.th2.read.db.core.DataSourceId
 import com.exactpro.th2.read.db.core.QueryConfiguration
@@ -152,7 +152,7 @@ class DataBaseReaderGrpcServer(
             }
             observer.onNext(
                 QueryResponse.newBuilder()
-                    .putAllRow(row.toMap())
+                    .putRows(row)
                     .setExecutionId(row.executionId)
                     .build()
             )
@@ -195,6 +195,15 @@ class DataBaseReaderGrpcServer(
         private val EXECUTION_COUNTER = AtomicLong(
             Instant.now().run { epochSecond * TimeUnit.SECONDS.toNanos(1) + nano }
         )
+
+        private fun QueryResponse.Builder.putRows(tableRow: TableRow) = apply {
+            tableRow.columns.forEach { (key, value) ->
+                // null values should be skipped because they aren't supported by Protobuf
+                if (value != null) {
+                    putRow(key, value.toStringValue())
+                }
+            }
+        }
     }
 }
 

--- a/core/src/main/kotlin/com/exactpro/th2/read/db/impl/grpc/DataBaseReaderGrpcServer.kt
+++ b/core/src/main/kotlin/com/exactpro/th2/read/db/impl/grpc/DataBaseReaderGrpcServer.kt
@@ -16,12 +16,17 @@
 
 package com.exactpro.th2.read.db.impl.grpc
 
+import com.exactpro.th2.common.event.Event
 import com.exactpro.th2.common.message.toJavaDuration
 import com.exactpro.th2.common.message.toJson
 import com.exactpro.th2.read.db.app.DataBaseReader
 import com.exactpro.th2.read.db.app.ExecuteQueryRequest
 import com.exactpro.th2.read.db.app.PullTableRequest
+import com.exactpro.th2.read.db.bootstrap.toMap
+import com.exactpro.th2.read.db.core.DataSourceConfiguration
 import com.exactpro.th2.read.db.core.DataSourceId
+import com.exactpro.th2.read.db.core.QueryConfiguration
+import com.exactpro.th2.read.db.core.QueryId
 import com.exactpro.th2.read.db.core.ResultListener
 import com.exactpro.th2.read.db.core.TableRow
 import com.exactpro.th2.read.db.core.UpdateListener
@@ -37,32 +42,42 @@ import com.google.protobuf.Empty
 import io.grpc.Status
 import io.grpc.stub.StreamObserver
 import mu.KotlinLogging
+import java.time.Instant
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicLong
 import com.exactpro.th2.read.db.grpc.QueryId as ProtoQueryId
 
 class DataBaseReaderGrpcServer(
     private val app: DataBaseReader,
+    private val getSourceCfg: (DataSourceId) -> DataSourceConfiguration,
+    private val getQueryCfg: (QueryId) -> QueryConfiguration,
+    private val onEvent: OnEvent,
 ) : ReadDbGrpc.ReadDbImplBase() {
     override fun execute(request: QueryRequest, responseObserver: StreamObserver<QueryResponse>) {
-        LOGGER.info { "Executing 'execute' grpc request ${request.toJson()}" }
+        val executionId = EXECUTION_COUNTER.incrementAndGet()
+        LOGGER.info { "Executing 'execute' grpc request ${request.toJson()}, execution id: $executionId" }
+        val event = Event.start()
+            .name("Execute '${request.queryId.id}' query ($executionId)")
+            .type("read-db.execute")
         try {
             val associatedMessageType: String? = if (request.hasAssociatedMessageType()) request.associatedMessageType.name else null
-            app.executeQuery(
-                request.run {
-                    ExecuteQueryRequest(
-                        sourceId.toModel(),
-                        beforeQueryIdsList.map(ProtoQueryId::toModel),
-                        queryId.toModel(),
-                        afterQueryIdsList.map(ProtoQueryId::toModel),
-                        parameters.toModel(),
-                    )
-                },
-                GrpcResultListener(responseObserver),
-            ) { row ->
-                associatedMessageType?.let { row.copy(associatedMessageType = it) } ?: row
+            val executeQueryRequest = request.run {
+                ExecuteQueryRequest(
+                    sourceId.toModel(),
+                    beforeQueryIdsList.map(ProtoQueryId::toModel),
+                    queryId.toModel(),
+                    afterQueryIdsList.map(ProtoQueryId::toModel),
+                    parameters.toModel(),
+                )
+            }
+            event.bodyData(executeQueryRequest.toBody(executionId))
+            app.executeQuery(executeQueryRequest, GrpcResultListener(responseObserver, event)) { row ->
+                row.copy(associatedMessageType = associatedMessageType, executionId = executionId)
             }
         } catch (ex: Exception) {
             LOGGER.error(ex) { "cannot execute request ${request.toJson()}" }
             responseObserver.onError(Status.INTERNAL.withDescription(ex.message).asRuntimeException())
+            event.exception(ex, true).also(onEvent::accept)
         }
     }
 
@@ -119,25 +134,43 @@ class DataBaseReaderGrpcServer(
         }
     }
 
-    private class GrpcResultListener(
+    inner class GrpcResultListener(
         private val observer: StreamObserver<QueryResponse>,
+        private val event: Event,
     ) : ResultListener {
         override fun onRow(sourceId: DataSourceId, row: TableRow) {
+            requireNotNull(row.executionId) {
+                "'Execution id' is null for row: $row"
+            }
             observer.onNext(
                 QueryResponse.newBuilder()
-                    .putAllRow(row.columns.mapValues { it.value.toString() })
+                    .putAllRow(row.toMap())
+                    .setExecutionId(row.executionId)
                     .build()
             )
         }
 
         override fun onError(error: Throwable) {
             observer.onError(error)
+            event.endTimestamp()
+                .exception(error, true)
+                .also(onEvent::accept)
         }
 
         override fun onComplete() {
             observer.onCompleted()
+            event.endTimestamp().also(onEvent::accept)
         }
     }
+
+    private fun ExecuteQueryRequest.toBody(executionId: Long) = ExecuteBodyData(
+        getSourceCfg(sourceId),
+        before.map(getQueryCfg),
+        getQueryCfg(queryId),
+        after.map(getQueryCfg),
+        parameters,
+        executionId
+    )
 
     private object DummyUpdateListener : UpdateListener {
         override fun onUpdate(dataSourceId: DataSourceId, row: TableRow, properties: Map<String, String>) = Unit
@@ -149,5 +182,13 @@ class DataBaseReaderGrpcServer(
 
     companion object {
         private val LOGGER = KotlinLogging.logger { }
+
+        private val EXECUTION_COUNTER = AtomicLong(
+            Instant.now().run { epochSecond * TimeUnit.SECONDS.toNanos(1) + nano }
+        )
     }
+}
+
+fun interface OnEvent {
+    fun accept(event: Event)
 }

--- a/core/src/main/kotlin/com/exactpro/th2/read/db/impl/grpc/DataBaseReaderGrpcServer.kt
+++ b/core/src/main/kotlin/com/exactpro/th2/read/db/impl/grpc/DataBaseReaderGrpcServer.kt
@@ -179,7 +179,7 @@ class DataBaseReaderGrpcServer(
         before.map(getQueryCfg),
         getQueryCfg(queryId),
         after.map(getQueryCfg),
-        parameters
+        this
     )
 
     private object DummyUpdateListener : UpdateListener {

--- a/core/src/main/kotlin/com/exactpro/th2/read/db/impl/grpc/ExecuteBodyData.kt
+++ b/core/src/main/kotlin/com/exactpro/th2/read/db/impl/grpc/ExecuteBodyData.kt
@@ -24,10 +24,10 @@ import com.fasterxml.jackson.annotation.JsonInclude
 
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 data class ExecuteBodyData(
+    val executionId: Long,
     val dataSource: DataSourceConfiguration,
     val beforeQueries: List<QueryConfiguration> = emptyList(),
     val query: QueryConfiguration,
     val afterQueries: List<QueryConfiguration> = emptyList(),
     val parameters: QueryParametersValues = emptyMap(),
-    val executionId: Long,
 ) : IBodyData

--- a/core/src/main/kotlin/com/exactpro/th2/read/db/impl/grpc/ExecuteBodyData.kt
+++ b/core/src/main/kotlin/com/exactpro/th2/read/db/impl/grpc/ExecuteBodyData.kt
@@ -17,9 +17,9 @@
 package com.exactpro.th2.read.db.impl.grpc
 
 import com.exactpro.th2.common.event.IBodyData
+import com.exactpro.th2.read.db.app.ExecuteQueryRequest
 import com.exactpro.th2.read.db.core.DataSourceConfiguration
 import com.exactpro.th2.read.db.core.QueryConfiguration
-import com.exactpro.th2.read.db.core.QueryParametersValues
 import com.fasterxml.jackson.annotation.JsonInclude
 
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
@@ -29,5 +29,5 @@ data class ExecuteBodyData(
     val beforeQueries: List<QueryConfiguration> = emptyList(),
     val query: QueryConfiguration,
     val afterQueries: List<QueryConfiguration> = emptyList(),
-    val parameters: QueryParametersValues = emptyMap(),
+    val request: ExecuteQueryRequest,
 ) : IBodyData

--- a/core/src/main/kotlin/com/exactpro/th2/read/db/impl/grpc/ExecuteBodyData.kt
+++ b/core/src/main/kotlin/com/exactpro/th2/read/db/impl/grpc/ExecuteBodyData.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 Exactpro (Exactpro Systems Limited)
+ * Copyright 2023 Exactpro (Exactpro Systems Limited)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,13 +14,20 @@
  * limitations under the License.
  */
 
-package com.exactpro.th2.read.db.core
+package com.exactpro.th2.read.db.impl.grpc
 
+import com.exactpro.th2.common.event.IBodyData
+import com.exactpro.th2.read.db.core.DataSourceConfiguration
+import com.exactpro.th2.read.db.core.QueryConfiguration
+import com.exactpro.th2.read.db.core.QueryParametersValues
 import com.fasterxml.jackson.annotation.JsonInclude
 
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
-data class QueryConfiguration(
-    val query: String,
-    val defaultParameters: QueryParametersValues = emptyMap(),
-    val messageType: String? = null,
-)
+data class ExecuteBodyData(
+    val dataSource: DataSourceConfiguration,
+    val beforeQueries: List<QueryConfiguration> = emptyList(),
+    val query: QueryConfiguration,
+    val afterQueries: List<QueryConfiguration> = emptyList(),
+    val parameters: QueryParametersValues = emptyMap(),
+    val executionId: Long,
+) : IBodyData

--- a/core/src/test/kotlin/com/exactpro/th2/read/db/app/FullReadDbIntegrationTest.kt
+++ b/core/src/test/kotlin/com/exactpro/th2/read/db/app/FullReadDbIntegrationTest.kt
@@ -1,0 +1,196 @@
+/*
+ * Copyright 2024 Exactpro (Exactpro Systems Limited)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.exactpro.th2.read.db.app
+
+import com.exactpro.th2.common.message.toJson
+import com.exactpro.th2.common.schema.factory.CommonFactory
+import com.exactpro.th2.read.db.annotations.IntegrationTest
+import com.exactpro.th2.read.db.bootstrap.setupApp
+import com.exactpro.th2.read.db.containers.MySqlContainer
+import com.exactpro.th2.read.db.grpc.QueryId
+import com.exactpro.th2.read.db.grpc.QueryRequest
+import com.exactpro.th2.read.db.grpc.ReadDbService
+import com.exactpro.th2.read.db.grpc.SourceId
+import com.exactpro.th2.test.annotations.CustomConfigProvider
+import com.exactpro.th2.test.annotations.Th2AppFactory
+import com.exactpro.th2.test.annotations.Th2IntegrationTest
+import com.exactpro.th2.test.annotations.Th2TestFactory
+import com.exactpro.th2.test.extension.CleanupExtension
+import com.exactpro.th2.test.spec.CradleSpec
+import com.exactpro.th2.test.spec.CustomConfigSpec
+import com.exactpro.th2.test.spec.GrpcSpec
+import com.exactpro.th2.test.spec.RabbitMqSpec
+import com.exactpro.th2.test.spec.pin
+import com.exactpro.th2.test.spec.pins
+import com.exactpro.th2.test.spec.publishers
+import com.exactpro.th2.test.spec.server
+import mu.KotlinLogging
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
+import java.sql.Connection
+
+
+@Th2IntegrationTest
+@IntegrationTest
+internal class FullReadDbIntegrationTest {
+    private val mysql = MySqlContainer()
+
+    @Suppress("unused")
+    val grpc = GrpcSpec.create()
+        .server<ReadDbService>()
+
+    @Suppress("unused")
+    val mq = RabbitMqSpec.create()
+        .pins {
+            publishers {
+                pin("out") {
+                    attributes("transport-group")
+                }
+            }
+        }
+
+    @Suppress("unused")
+    val cradle = CradleSpec.create()
+        .disableAutoPages()
+        .reuseKeyspace()
+
+    @BeforeAll
+    fun init() {
+        mysql.withDatabaseName("test_data")
+            .start()
+    }
+
+    @AfterAll
+    fun cleanup() {
+        mysql.stop()
+    }
+
+    @BeforeEach
+    fun setup() {
+        execute {
+            dropTable()
+            initTestData()
+        }
+    }
+
+    @Test
+    @CustomConfigProvider("config")
+    fun `exception during query execution does not block grpc`(
+        @Th2AppFactory factory: CommonFactory,
+        @Th2TestFactory test: CommonFactory,
+        resourceCleaner: CleanupExtension.Registry,
+    ) {
+        setupApp(factory) { name, resource -> resourceCleaner.add(name, resource) }
+        val readDb = test.grpcRouter.getService(ReadDbService::class.java)
+
+        assertThrows<Exception> {
+            readDb.execute(
+                QueryRequest.newBuilder()
+                    .setQueryId(QueryId.newBuilder().setId("wrong_db"))
+                    .setSourceId(SourceId.newBuilder().setId("persons"))
+                    .build()
+            ).asSequence().toList()
+        }
+    }
+
+    @Test
+    @CustomConfigProvider("config")
+    fun `query execution using grpc works`(
+        @Th2AppFactory factory: CommonFactory,
+        @Th2TestFactory test: CommonFactory,
+        resourceCleaner: CleanupExtension.Registry,
+    ) {
+        setupApp(factory) { name, resource -> resourceCleaner.add(name, resource) }
+        val readDb = test.grpcRouter.getService(ReadDbService::class.java)
+
+        val results = assertDoesNotThrow {
+            readDb.execute(
+                QueryRequest.newBuilder()
+                    .setQueryId(QueryId.newBuilder().setId("all"))
+                    .setSourceId(SourceId.newBuilder().setId("persons"))
+                    .build()
+            ).asSequence().toList()
+        }
+
+        Assertions.assertEquals(0, results.size) {
+            "unexpected results: ${results.map { it.toJson() }}"
+        }
+    }
+
+    fun config(): CustomConfigSpec {
+        return CustomConfigSpec.fromString(
+            """
+            {
+                "dataSources": {
+                    "persons": {
+                        "url": "${mysql.jdbcUrl}",
+                        "username": "${mysql.username}",
+                        "password": "${mysql.password}"
+                    }
+                },
+                "queries": {
+                    "all": {
+                        "query": "SELECT * FROM test_data.person;"
+                    },
+                    "wrong_db": {
+                        "query": "SELECT * FROM test_dat.person;"
+                    }
+                },
+                "useTransport": true
+            }
+            """.trimIndent()
+        )
+    }
+
+    private fun execute(action: Connection.() -> Unit) {
+        mysql.createConnection("").use { it.action() }
+    }
+
+    private fun Connection.initTestData() {
+        createStatement()
+            .execute(
+                """
+                    CREATE TABLE `test_data`.`person` (
+                      `id` INT NOT NULL AUTO_INCREMENT,
+                      `name` VARCHAR(45) NOT NULL,
+                      `birthday` DATE NOT NULL,
+                      `data` BLOB NOT NULL,
+                      PRIMARY KEY (`id`));
+                """.trimIndent()
+            )
+        LOGGER.info { "table created" }
+    }
+
+    private fun Connection.dropTable() {
+        createStatement()
+            .execute(
+                """
+                DROP TABLE IF EXISTS `test_data`.`person`;
+            """.trimIndent()
+            )
+        LOGGER.info { "table dropped" }
+    }
+
+    companion object {
+        private val LOGGER = KotlinLogging.logger { }
+    }
+}

--- a/core/src/test/kotlin/com/exactpro/th2/read/db/impl/grpc/DataBaseReaderGrpcServerIntegrationTest.kt
+++ b/core/src/test/kotlin/com/exactpro/th2/read/db/impl/grpc/DataBaseReaderGrpcServerIntegrationTest.kt
@@ -1,0 +1,377 @@
+/*
+ * Copyright 2023 Exactpro (Exactpro Systems Limited)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.exactpro.th2.read.db.impl.grpc
+
+import com.exactpro.th2.common.event.Event
+import com.exactpro.th2.common.grpc.EventStatus
+import com.exactpro.th2.common.schema.factory.AbstractCommonFactory.MAPPER
+import com.exactpro.th2.read.db.annotations.IntegrationTest
+import com.exactpro.th2.read.db.app.DataBaseReader
+import com.exactpro.th2.read.db.app.DataBaseReaderConfiguration
+import com.exactpro.th2.read.db.containers.MySqlContainer
+import com.exactpro.th2.read.db.core.DataSourceConfiguration
+import com.exactpro.th2.read.db.core.DataSourceId
+import com.exactpro.th2.read.db.core.MessageLoader
+import com.exactpro.th2.read.db.core.QueryConfiguration
+import com.exactpro.th2.read.db.core.QueryId
+import com.exactpro.th2.read.db.core.RowListener
+import com.exactpro.th2.read.db.core.TableRow
+import com.exactpro.th2.read.db.core.UpdateListener
+import com.exactpro.th2.read.db.grpc.QueryRequest
+import com.exactpro.th2.read.db.grpc.QueryResponse
+import com.exactpro.th2.read.db.grpc.ReadDbGrpc
+import com.exactpro.th2.read.db.impl.grpc.util.toModel
+import com.google.protobuf.ByteString
+import io.grpc.BindableService
+import io.grpc.Context
+import io.grpc.ManagedChannel
+import io.grpc.Server
+import io.grpc.inprocess.InProcessChannelBuilder
+import io.grpc.inprocess.InProcessServerBuilder
+import io.grpc.stub.StreamObserver
+import io.netty.buffer.ByteBufUtil.decodeHexDump
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import mu.KotlinLogging
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.verifyNoMoreInteractions
+import strikt.api.expectThat
+import strikt.assertions.contains
+import strikt.assertions.containsExactly
+import strikt.assertions.isEqualTo
+import java.io.ByteArrayInputStream
+import java.sql.Connection
+import java.sql.Date
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneOffset
+import java.time.temporal.ChronoUnit
+import java.util.concurrent.TimeUnit
+import kotlin.test.assertNotNull
+
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@IntegrationTest
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class DataBaseReaderGrpcServerIntegrationTest {
+    private val mysql = MySqlContainer()
+    private val persons = (1..30).map {
+        Person("person$it", Instant.now().truncatedTo(ChronoUnit.DAYS), "test-data-$it".toByteArray())
+    }
+
+    private data class Person(val name: String, val birthday: Instant, val data: ByteArray) {
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (javaClass != other?.javaClass) return false
+
+            other as Person
+
+            if (name != other.name) return false
+            if (birthday != other.birthday) return false
+            if (!data.contentEquals(other.data)) return false
+
+            return true
+        }
+
+        override fun hashCode(): Int {
+            var result = name.hashCode()
+            result = 31 * result + birthday.hashCode()
+            result = 31 * result + data.contentHashCode()
+            return result
+        }
+    }
+
+    @BeforeAll
+    fun init() {
+        mysql.withDatabaseName("test_data").start()
+    }
+
+    @AfterAll
+    fun cleanup() {
+        mysql.stop()
+    }
+
+    @BeforeEach
+    fun setup() {
+        execute {
+            dropTable()
+            initTestData()
+        }
+    }
+
+    @Test
+    fun `test execute gRPC request`() {
+        val genericUpdateListener = mock<UpdateListener> { }
+        val genericRowListener = mock<RowListener> { }
+        val messageLoader = mock<MessageLoader> { }
+        val onEvent = mock<OnEvent> { }
+        val streamObserver = mock<StreamObserver<QueryResponse>> { }
+
+        val sourceId = "persons"
+        val queryId = "select"
+        val cfg = DataBaseReaderConfiguration(
+            mapOf(
+                DataSourceId(sourceId) to DataSourceConfiguration(
+                    mysql.jdbcUrl,
+                    mysql.username,
+                    mysql.password,
+                )
+            ),
+            mapOf(
+                QueryId(queryId) to QueryConfiguration(
+                    "SELECT * FROM test_data.person WHERE \${fromId:integer} < id AND id < \${toId:integer}",
+                    mapOf(
+                        "fromId" to listOf(Int.MIN_VALUE.toString()),
+                        "toId" to listOf(Int.MAX_VALUE.toString())
+                    )
+                ),
+            )
+        )
+        val request = QueryRequest.newBuilder().apply {
+            sourceIdBuilder.setId(sourceId)
+            queryIdBuilder.setId(queryId)
+            parametersBuilder
+                .putValues("fromId", "10")
+                .putValues("toId", "20")
+        }.build()
+
+        runTest {
+            val reader = DataBaseReader.createDataBaseReader(
+                cfg,
+                this,
+                genericUpdateListener,
+                genericRowListener,
+                messageLoader,
+            )
+
+            val service = DataBaseReaderGrpcServer(
+                reader,
+                { cfg.dataSources[it] ?: error("'$it' data source isn't found in custom config") },
+                { cfg.queries[it] ?: error("'$it' query isn't found in custom config") },
+                onEvent,
+            )
+            runCurrent()
+
+            GrpcTestHolder(service).use { (stub) ->
+                withCancellation {
+                    stub.execute(request, streamObserver)
+                    advanceUntilIdle()
+                }
+            }
+
+            val expectedData = persons.asSequence().drop(10).take(9).toList()
+
+            verifyNoInteractions(genericUpdateListener)
+            verifyNoInteractions(messageLoader)
+
+            val executionIds = hashSetOf<Long>()
+            genericRowListener.assertCaptured(expectedData).also(executionIds::add)
+            streamObserver.assertCaptured(expectedData).also(executionIds::add)
+            onEvent.assertCaptured(cfg, request).also(executionIds::add)
+            assertEquals(1, executionIds.size, "execution ids mismatch $executionIds")
+        }
+    }
+
+    private fun RowListener.assertCaptured(persons: List<Person>): Long {
+        val captor = argumentCaptor<TableRow>()
+        verify(this, times(persons.size)).onRow(any(), captor.capture())
+        verifyNoMoreInteractions(this)
+
+        captor.allValues.map {
+            Person(
+                checkNotNull(it.columns["name"]).toString(),
+                (checkNotNull(it.columns["birthday"]) as LocalDate).atStartOfDay().toInstant(ZoneOffset.UTC),
+                (checkNotNull(it.columns["data"]) as ByteArray),
+            )
+        }.also {
+            expectThat(it).containsExactly(persons)
+        }
+
+        val executionIds = captor.allValues.asSequence()
+            .map(TableRow::executionId)
+            .toSet()
+        assertEquals(1, executionIds.size)
+        return assertNotNull(executionIds.single())
+    }
+
+    private fun StreamObserver<QueryResponse>.assertCaptured(persons: List<Person>): Long {
+        val captor = argumentCaptor<QueryResponse> { }
+        verify(this, times(persons.size)).onNext(captor.capture())
+        verify(this).onCompleted()
+        verifyNoMoreInteractions(this)
+
+        captor.allValues.map {
+            Person(
+                it.getRowOrThrow("name").toString(),
+                LocalDate.parse(it.getRowOrThrow("birthday")).atStartOfDay().toInstant(ZoneOffset.UTC),
+                decodeHexDump(it.getRowOrThrow("data")),
+            )
+        }.also {
+            expectThat(it).containsExactly(persons)
+        }
+        val executionIds = captor.allValues.asSequence()
+            .map(QueryResponse::getExecutionId)
+            .toSet()
+        assertEquals(1, executionIds.size)
+
+        return executionIds.single()
+    }
+
+    private fun OnEvent.assertCaptured(cfg: DataBaseReaderConfiguration, request: QueryRequest): Long {
+        val captor = argumentCaptor<Event> { }
+        verify(this).accept(captor.capture())
+
+        return captor.firstValue.toProto("test-book").let { event ->
+            expectThat(event) {
+                get { name }.contains(Regex("Execute '${request.queryId.id}' query \\(.*\\)"))
+                get { type }.isEqualTo("read-db.execute")
+                get { status }.isEqualTo(EventStatus.SUCCESS)
+                get { body.parseSingle<ExecuteBodyData>() }.apply {
+                    get { dataSource }.isEqualTo(cfg.dataSources[request.sourceId.toModel()]?.copy(password = null))
+                    get { beforeQueries }.isEqualTo(request.beforeQueryIdsList.map { requireNotNull(cfg.queries[it.toModel()]) })
+                    get { query }.isEqualTo(cfg.queries[request.queryId.toModel()])
+                    get { afterQueries }.isEqualTo(request.afterQueryIdsList.map { requireNotNull(cfg.queries[it.toModel()]) })
+                }
+            }
+
+            event.body.parseSingle<ExecuteBodyData>().executionId
+        }
+    }
+
+    private inline fun <reified T> ByteString.parseSingle(): T = MAPPER.readValue<List<T>>(
+        toString(Charsets.UTF_8),
+        MAPPER.typeFactory.constructCollectionType(List::class.java, T::class.java)
+    ).single()
+
+    private fun execute(action: Connection.() -> Unit) {
+        mysql.createConnection("").use { it.action() }
+    }
+
+    private fun Connection.initTestData() {
+        createStatement()
+            .execute(
+                """
+                    CREATE TABLE `test_data`.`person` (
+                      `id` INT NOT NULL AUTO_INCREMENT,
+                      `name` VARCHAR(45) NOT NULL,
+                      `birthday` DATE NOT NULL,
+                      `data` BLOB NOT NULL,
+                      PRIMARY KEY (`id`));
+                """.trimIndent()
+            )
+        LOGGER.info { "table created" }
+        insertData(persons)
+        LOGGER.info { "Initial data inserted" }
+    }
+
+    private fun Connection.dropTable() {
+        createStatement()
+            .execute(
+                """
+                DROP TABLE IF EXISTS `test_data`.`person`;
+            """.trimIndent()
+            )
+        LOGGER.info { "table dropped" }
+    }
+
+    private fun Connection.insertData(persons: List<Person>) {
+        val prepareStatement = prepareStatement(
+            """
+                        INSERT INTO `test_data`.`person` (`name`, `birthday`, `data`)
+                        VALUES
+                        (?, ?, ?);
+                    """.trimIndent()
+        )
+        for (person in persons) {
+            prepareStatement.setString(1, person.name)
+            prepareStatement.setDate(2, Date(person.birthday.toEpochMilli()))
+            prepareStatement.setBlob(3, ByteArrayInputStream(person.data))
+            prepareStatement.addBatch()
+        }
+        prepareStatement.executeBatch()
+    }
+
+    private class GrpcTestHolder(
+        service: BindableService
+    ) : AutoCloseable {
+        private val inProcessServer: Server
+
+        private val inProcessChannel: ManagedChannel
+
+        val stub: ReadDbGrpc.ReadDbStub
+
+        init {
+            inProcessServer = InProcessServerBuilder
+                .forName(SERVER_NAME)
+                .addService(service)
+                .directExecutor()
+                .build()
+                .also(Server::start)
+
+            inProcessChannel = InProcessChannelBuilder
+                .forName(SERVER_NAME)
+                .directExecutor()
+                .build()
+
+            stub = ReadDbGrpc.newStub(inProcessChannel)
+        }
+
+        operator fun component1(): ReadDbGrpc.ReadDbStub = stub
+
+        override fun close() {
+            LOGGER.info { "Shutdown process channel" }
+            inProcessChannel.shutdown()
+            if (!inProcessChannel.awaitTermination(1, TimeUnit.MINUTES)) {
+                LOGGER.warn { "Process channel couldn't stop during 1 min" }
+                inProcessChannel.shutdownNow()
+                LOGGER.warn { "Process channel shutdown now, is terminated: ${inProcessChannel.isTerminated}" }
+            }
+            LOGGER.info { "Shutdown process server" }
+            inProcessServer.shutdown()
+            if (!inProcessServer.awaitTermination(1, TimeUnit.MINUTES)) {
+                LOGGER.warn { "Process server couldn't stop during 1 min" }
+                inProcessServer.shutdownNow()
+                LOGGER.warn { "Process server shutdown now, is terminated: ${inProcessChannel.isTerminated}" }
+            }
+        }
+    }
+
+    companion object {
+        private val LOGGER = KotlinLogging.logger { }
+
+        private const val SERVER_NAME = "server"
+
+        private fun <T> withCancellation(code: () -> T): T {
+            return Context.current().withCancellation().use { context ->
+                context.call { code() }
+            }
+        }
+    }
+}

--- a/core/src/test/kotlin/com/exactpro/th2/read/db/impl/grpc/ExecuteBodyDataTest.kt
+++ b/core/src/test/kotlin/com/exactpro/th2/read/db/impl/grpc/ExecuteBodyDataTest.kt
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2023 Exactpro (Exactpro Systems Limited)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.exactpro.th2.read.db.impl.grpc
+
+import com.exactpro.th2.common.schema.factory.AbstractCommonFactory.MAPPER
+import com.exactpro.th2.read.db.core.DataSourceConfiguration
+import com.exactpro.th2.read.db.core.QueryConfiguration
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class ExecuteBodyDataTest {
+
+    @Test
+    fun `serializes body data - fulfilled`() {
+        val bean = ExecuteBodyData(
+            DataSourceConfiguration(
+                "jdbc:mysql://localhost:1234/test_data",
+                "test-username",
+                "test-password",
+                mapOf("test-property" to "test-property-value")
+            ),
+            listOf(
+                QueryConfiguration(
+                    "test-before-query",
+                    mapOf("test-before-parameter" to listOf("test-before-parameter-value"))
+                )
+            ),
+            QueryConfiguration(
+                "test-query",
+                mapOf("test-parameter" to listOf("test-parameter-value")),
+                "test-message-type"
+            ),
+            listOf(
+                QueryConfiguration(
+                    "test-after-query",
+                    mapOf("test-after-parameter" to listOf("test-after-parameter-value"))
+                )
+            ),
+            mapOf("test-user-parameter" to listOf("test-user-parameter-value")),
+            123
+        )
+
+        val actual = MAPPER.writeValueAsString(bean)
+        assertEquals(
+            """
+            |{
+              |"dataSource":{
+                |"url":"jdbc:mysql://localhost:1234/test_data",
+                |"username":"test-username",
+                |"properties":{
+                  |"test-property":"test-property-value"
+                |}
+              |},
+              |"beforeQueries":[
+                |{
+                  |"query":"test-before-query",
+                  |"defaultParameters":{
+                    |"test-before-parameter":[
+                      |"test-before-parameter-value"
+                    |]
+                  |}
+                |}
+              |],
+              |"query":{
+                |"query":"test-query",
+                |"defaultParameters":{
+                  |"test-parameter":[
+                    |"test-parameter-value"
+                  |]
+                |},
+                |"messageType":"test-message-type"
+              |},
+              |"afterQueries":[
+                |{
+                  |"query":"test-after-query",
+                  |"defaultParameters":{
+                    |"test-after-parameter":[
+                      |"test-after-parameter-value"
+                    |]
+                  |}
+                |}
+              |],
+              |"parameters":{
+                |"test-user-parameter":[
+                  |"test-user-parameter-value"
+                |]
+              |},
+              |"executionId":123
+            |}
+        """.trimMargin().replace(Regex("\n"), ""), actual
+        )
+    }
+
+    @Test
+    fun `serializes body data - low-filled`() {
+        val bean = ExecuteBodyData(
+            DataSourceConfiguration(
+                "jdbc:mysql://localhost:1234/test_data",
+                "test-username",
+                "test-password"
+            ),
+            emptyList(),
+            QueryConfiguration(
+                "test-query",
+            ),
+            emptyList(),
+            emptyMap(),
+            123
+        )
+
+        val actual = MAPPER.writeValueAsString(bean)
+        assertEquals(
+            """
+            |{
+              |"dataSource":{
+                |"url":"jdbc:mysql://localhost:1234/test_data",
+                |"username":"test-username"
+              |},
+              |"query":{
+                |"query":"test-query"
+              |},
+              |"executionId":123
+            |}
+        """.trimMargin().replace(Regex("\n"), ""), actual
+        )
+    }
+}

--- a/core/src/test/kotlin/com/exactpro/th2/read/db/impl/grpc/ExecuteBodyDataTest.kt
+++ b/core/src/test/kotlin/com/exactpro/th2/read/db/impl/grpc/ExecuteBodyDataTest.kt
@@ -17,8 +17,11 @@
 package com.exactpro.th2.read.db.impl.grpc
 
 import com.exactpro.th2.common.schema.factory.AbstractCommonFactory.MAPPER
+import com.exactpro.th2.read.db.app.ExecuteQueryRequest
 import com.exactpro.th2.read.db.core.DataSourceConfiguration
+import com.exactpro.th2.read.db.core.DataSourceId
 import com.exactpro.th2.read.db.core.QueryConfiguration
+import com.exactpro.th2.read.db.core.QueryId
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
@@ -51,7 +54,13 @@ class ExecuteBodyDataTest {
                     mapOf("test-after-parameter" to listOf("test-after-parameter-value"))
                 )
             ),
-            mapOf("test-user-parameter" to listOf("test-user-parameter-value"))
+            ExecuteQueryRequest(
+                DataSourceId("test-data-source-id"),
+                listOf(QueryId("test-before-query-id")),
+                QueryId("test-query-id"),
+                listOf(QueryId("test-after-query-id")),
+                mapOf("test-user-parameter" to listOf("test-user-parameter-value"))
+            )
         )
 
         val actual = MAPPER.writeValueAsString(bean)
@@ -95,10 +104,20 @@ class ExecuteBodyDataTest {
                   |}
                 |}
               |],
-              |"parameters":{
-                |"test-user-parameter":[
-                  |"test-user-parameter-value"
-                |]
+              |"request":{
+                |"sourceId":"test-data-source-id",
+                |"before":[
+                  |"test-before-query-id"
+                |],
+                |"queryId":"test-query-id",
+                |"after":[
+                    |"test-after-query-id"
+                |],
+                |"parameters":{
+                  |"test-user-parameter":[
+                    |"test-user-parameter-value"
+                  |]
+                |}
               |}
             |}
         """.trimMargin().replace(Regex("\n"), ""), actual
@@ -119,7 +138,13 @@ class ExecuteBodyDataTest {
                 "test-query",
             ),
             emptyList(),
-            emptyMap()
+            ExecuteQueryRequest(
+                DataSourceId("test-data-source-id"),
+                emptyList(),
+                QueryId("test-query-id"),
+                emptyList(),
+                emptyMap()
+            )
         )
 
         val actual = MAPPER.writeValueAsString(bean)
@@ -133,6 +158,10 @@ class ExecuteBodyDataTest {
               |},
               |"query":{
                 |"query":"test-query"
+              |},
+              |"request":{
+                |"sourceId":"test-data-source-id",
+                |"queryId":"test-query-id"
               |}
             |}
         """.trimMargin().replace(Regex("\n"), ""), actual

--- a/core/src/test/kotlin/com/exactpro/th2/read/db/impl/grpc/ExecuteBodyDataTest.kt
+++ b/core/src/test/kotlin/com/exactpro/th2/read/db/impl/grpc/ExecuteBodyDataTest.kt
@@ -27,6 +27,7 @@ class ExecuteBodyDataTest {
     @Test
     fun `serializes body data - fulfilled`() {
         val bean = ExecuteBodyData(
+            123,
             DataSourceConfiguration(
                 "jdbc:mysql://localhost:1234/test_data",
                 "test-username",
@@ -50,14 +51,14 @@ class ExecuteBodyDataTest {
                     mapOf("test-after-parameter" to listOf("test-after-parameter-value"))
                 )
             ),
-            mapOf("test-user-parameter" to listOf("test-user-parameter-value")),
-            123
+            mapOf("test-user-parameter" to listOf("test-user-parameter-value"))
         )
 
         val actual = MAPPER.writeValueAsString(bean)
         assertEquals(
             """
             |{
+              |"executionId":123,
               |"dataSource":{
                 |"url":"jdbc:mysql://localhost:1234/test_data",
                 |"username":"test-username",
@@ -98,8 +99,7 @@ class ExecuteBodyDataTest {
                 |"test-user-parameter":[
                   |"test-user-parameter-value"
                 |]
-              |},
-              |"executionId":123
+              |}
             |}
         """.trimMargin().replace(Regex("\n"), ""), actual
         )
@@ -108,6 +108,7 @@ class ExecuteBodyDataTest {
     @Test
     fun `serializes body data - low-filled`() {
         val bean = ExecuteBodyData(
+            123,
             DataSourceConfiguration(
                 "jdbc:mysql://localhost:1234/test_data",
                 "test-username",
@@ -118,22 +119,21 @@ class ExecuteBodyDataTest {
                 "test-query",
             ),
             emptyList(),
-            emptyMap(),
-            123
+            emptyMap()
         )
 
         val actual = MAPPER.writeValueAsString(bean)
         assertEquals(
             """
             |{
+              |"executionId":123,
               |"dataSource":{
                 |"url":"jdbc:mysql://localhost:1234/test_data",
                 |"username":"test-username"
               |},
               |"query":{
                 |"query":"test-query"
-              |},
-              |"executionId":123
+              |}
             |}
         """.trimMargin().replace(Regex("\n"), ""), actual
         )

--- a/grpc/README.md
+++ b/grpc/README.md
@@ -10,6 +10,7 @@ You can:
 
 ## 0.0.7
 + added execution_id to the QueryResponse
++ added parent_event_id to the QueryRequest
 
 ## 0.0.6
 + added before_init_query_ids, after_init_query_ids, before_update_query_ids, after_update_query_ids to the DbPullRequest

--- a/grpc/README.md
+++ b/grpc/README.md
@@ -1,4 +1,4 @@
-# gRPC for read-db (0.0.6)
+# gRPC for read-db (0.0.7)
 
 The read-db provides you with gRPC interface for interacting with database.
 You can:
@@ -7,6 +7,9 @@ You can:
 + submit pulling requests and stop them - `StartPulling` and `StopPulling` methods
 
 # Release notes:
+
+## 0.0.7
++ added execution_id to the QueryResponse
 
 ## 0.0.6
 + added before_init_query_ids, after_init_query_ids, before_update_query_ids, after_update_query_ids to the DbPullRequest

--- a/grpc/build.gradle
+++ b/grpc/build.gradle
@@ -34,6 +34,7 @@ configurations.configureEach {
 dependencies {
     api "com.google.protobuf:protobuf-java-util"
     api "io.grpc:grpc-stub"
+    api "com.exactpro.th2:grpc-common:4.3.0-dev"
     implementation "io.grpc:grpc-protobuf"
     implementation "io.grpc:grpc-core"
     implementation "io.grpc:grpc-netty"

--- a/grpc/gradle.properties
+++ b/grpc/gradle.properties
@@ -1,3 +1,3 @@
 kotlin.code.style=official
-release_version=0.0.6
+release_version=0.0.7
 description=gRPC API for executing requests in read-db application

--- a/grpc/package_info.json
+++ b/grpc/package_info.json
@@ -1,4 +1,4 @@
 {
     "package_name": "th2_grpc_read_db",
-    "package_version": "0.0.6"
+    "package_version": "0.0.7"
 }

--- a/grpc/proto/th2_grpc_read_db/read_db.proto
+++ b/grpc/proto/th2_grpc_read_db/read_db.proto
@@ -34,10 +34,12 @@ message QueryRequest {
   AssociatedMessageType associated_message_type = 4;
   repeated QueryId before_query_ids = 5;
   repeated QueryId after_query_ids = 6;
+//  maybe add parent event id parameter
 }
 
 message QueryResponse {
   map<string, string> row = 1;
+  int64 execution_id = 2;
 }
 
 message AssociatedMessageType {

--- a/grpc/proto/th2_grpc_read_db/read_db.proto
+++ b/grpc/proto/th2_grpc_read_db/read_db.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 
 package th2.read_db;
 
+import "th2_grpc_common/common.proto";
 import "google/protobuf/duration.proto";
 import "google/protobuf/empty.proto";
 import "google/protobuf/timestamp.proto";
@@ -34,7 +35,7 @@ message QueryRequest {
   AssociatedMessageType associated_message_type = 4;
   repeated QueryId before_query_ids = 5;
   repeated QueryId after_query_ids = 6;
-//  maybe add parent event id parameter
+  EventID parent_event_id = 7;
 }
 
 message QueryResponse {

--- a/grpc/requirements.txt
+++ b/grpc/requirements.txt
@@ -13,4 +13,5 @@
 #   limitations under the License.
 
 grpcio-tools==1.56.0
+th2-grpc-common==4.3.0.dev0
 mypy-protobuf==3.4

--- a/grpc/setup.py
+++ b/grpc/setup.py
@@ -121,6 +121,7 @@ setup(
     python_requires='>=3.7',
     install_requires=[
         'grpcio-tools==1.56.0',
+        'th2-grpc-common==4.3.0.dev0',
         'mypy-protobuf==3.4'
     ],
     packages=packages,

--- a/oracle-log-miner.md
+++ b/oracle-log-miner.md
@@ -169,7 +169,6 @@ spec:
       maxDelayMillis: 1000
       maxBatchSize: 100
     eventPublication:
-      maxBatchSizeInBytes: 1048576
       maxBatchSizeInItems: 100
       maxFlushTime: 1000
     useTransport: true

--- a/oracle-log-miner.md
+++ b/oracle-log-miner.md
@@ -1,0 +1,205 @@
+# Pull Oracle redo log
+
+The most crucial structure for recovery operations is the [redo log](https://docs.oracle.com/cd/A97385_01/server.920/a96521/onlineredo.htm)
+`Redo logs` contain information for recovery queries executed in site identifier (`SID`).
+Also, an administrator can enable [Supplemental Logging](https://docs.oracle.com/cd/A97385_01/server.920/a96521/logminer.htm#25840) to store reconstructed SQL statements. 
+After that an administrator can run [Log Miner](https://docs.oracle.com/cd/A97385_01/server.920/a96521/logminer.htm) 
+and read reconstructed SQL statements from a special dynamic view `V$LOGMNR_CONTENTS`
+
+## Create administrator role to use `Log Miner`
+
+Oracle user should have special permissions to work with `Log Miner`.
+All instructions below should be executed under `sys` user.
+
+```roomsql
+CREATE USER <user> IDENTIFIED BY <pass> DEFAULT TABLESPACE users QUOTA UNLIMITED ON users ACCOUNT UNLOCK;
+
+GRANT DBA to <user>;
+GRANT CREATE SESSION TO <user>;
+GRANT EXECUTE_CATALOG_ROLE TO <user>;
+GRANT EXECUTE ON DBMS_LOGMNR TO <user>;
+GRANT SELECT ON V_$DATABASE TO <user>;
+GRANT SELECT ON V_$LOGMNR_CONTENTS TO <user>;
+GRANT SELECT ON V_$ARCHIVED_LOG TO <user>;
+GRANT SELECT ON V_$LOG TO <user>;
+GRANT SELECT ON V_$LOGFILE TO <user>;
+```
+
+All instructions below should be executed under created user.
+
+## `Supplemental Logging` management
+
+Oracle begins storing additional information into `Redo logs` after enabling `Supplemental Logging`.
+It means that `Supplemental Logging` should be enabled before pulling data.
+
+### Check
+```roomsql
+SELECT SUPPLEMENTAL_LOG_DATA_MIN FROM V$DATABASE;
+```
+```roomsql
+SUPPLEME
+--------
+YES
+```
+
+### Enable
+
+Enable `Supplemental Logging` for `SID`
+```roomsql
+ALTER DATABASE ADD SUPPLEMENTAL LOG DATA;
+```
+
+### Disable
+```roomsql
+ALTER DATABASE DROP SUPPLEMENTAL LOG DATA;
+```
+
+## `Log miner` management
+
+### Show redo log files
+```roomsql
+SELECT distinct member LOGFILENAME FROM V$LOGFILE;
+```
+```roomsql
+LOGFILENAME
+--------------------------------------------------------------------------------
+/opt/oracle/oradata/XE/redo01.log
+/opt/oracle/oradata/XE/redo02.log
+/opt/oracle/oradata/XE/redo03.log
+```
+
+### Configure `Log miner`
+```roomsql
+EXECUTE DBMS_LOGMNR.ADD_LOGFILE (LOGFILENAME => '/opt/oracle/oradata/XE/redo01.log', OPTIONS => DBMS_LOGMNR.NEW);
+EXECUTE DBMS_LOGMNR.ADD_LOGFILE (LOGFILENAME => '/opt/oracle/oradata/XE/redo02.log', OPTIONS => DBMS_LOGMNR.ADDFILE);
+EXECUTE DBMS_LOGMNR.ADD_LOGFILE (LOGFILENAME => '/opt/oracle/oradata/XE/redo03.log', OPTIONS => DBMS_LOGMNR.ADDFILE);
+```
+```roomsql
+PL/SQL procedure successfully completed.
+```
+
+### Start `Log miner`
+```roomsql
+EXECUTE DBMS_LOGMNR.START_LOGMNR (OPTIONS => DBMS_LOGMNR.DICT_FROM_ONLINE_CATALOG + DBMS_LOGMNR.COMMITTED_DATA_ONLY);
+```
+```roomsql
+PL/SQL procedure successfully completed.
+```
+
+### Select SQL statement
+
+```roomsql
+SELECT SCN, TIMESTAMP, OPERATION, TABLE_NAME, ROW_ID, SQL_REDO FROM V$LOGMNR_CONTENTS;
+```
+```roomsql
+SCN     TIMESTAMP            OPERATION TABLE_NAME ROW_ID             SQL_REDO
+------- -------------------- --------- ---------- ------------------ ------------
+...
+3627247 06-Dec-2023 08:54:31 INSERT    EMPLOYEE   AAASt5AAHAAAAFcAAA insert into "<user>"."EMPLOYEE"("ID","NAME","TITLE","SALARY","BONUS_STRUCTURE","TIME_OFF","SICK_TIME", ...
+...
+3627285 06-Dec-2023 08:54:31 UPDATE    EMPLOYEE   AAASt5AAHAAAAFcAAA update "<user>"."EMPLOYEE" set "SAVINGS" = '10' where "SAVINGS" = '1' and ROWID = 'AAASt5AAHAAAAFcAAA';
+...
+3627294	06-Dec-2023 08:54:31 DELETE    EMPLOYEE   AAASt5AAHAAAAFcAAA delete from "<user>"."EMPLOYEE" where "ID" = '1' and "NAME" = 'Chris Montgomery                     ', ...
+...
+```
+
+The whole list of columns is described in the [V$LOGMNR_CONTENTS](https://docs.oracle.com/en/database/oracle/oracle-database/19/refrn/V-LOGMNR_CONTENTS.html#GUID-B9196942-07BF-4935-B603-FA875064F5C3)
+
+### Stop `Log miner`
+```roomsql
+EXECUTE DBMS_LOGMNR.END_LOGMNR;
+```
+```roomsql
+PL/SQL procedure successfully completed.
+```
+
+## th2-read-db configuration
+```yaml
+apiVersion: th2.exactpro.com/v2
+kind: Th2Box
+metadata:
+  name: read-db
+spec:
+  imageName: ghcr.io/th2-net/th2-read-db
+  imageVersion: 0.7.0-dev
+  type: th2-read
+  customConfig:
+    dataSources:
+      db:
+        url: "jdbc:oracle:thin:@$<host>:1521:XE"
+        username: <user>
+        password: <password>
+    queries:
+      add-logfile-1:
+        query: "{CALL DBMS_LOGMNR.ADD_LOGFILE (LOGFILENAME => '/opt/oracle/oradata/XE/redo01.log', OPTIONS => DBMS_LOGMNR.NEW)}"
+      add-logfile-2:
+        query: "{CALL DBMS_LOGMNR.ADD_LOGFILE (LOGFILENAME => '/opt/oracle/oradata/XE/redo02.log', OPTIONS => DBMS_LOGMNR.ADDFILE)}"
+      add-logfile-3:
+        query: "{CALL DBMS_LOGMNR.ADD_LOGFILE (LOGFILENAME => '/opt/oracle/oradata/XE/redo03.log', OPTIONS => DBMS_LOGMNR.ADDFILE)}"
+      start-log-miner:
+        query: "{CALL DBMS_LOGMNR.START_LOGMNR (OPTIONS => DBMS_LOGMNR.DICT_FROM_ONLINE_CATALOG + DBMS_LOGMNR.COMMITTED_DATA_ONLY)}"
+      end-log-miner:
+        query: "{CALL DBMS_LOGMNR.END_LOGMNR}"
+      update-logmnr-contents:
+        query: >
+          SELECT SCN, TIMESTAMP, TABLE_NAME, ROW_ID, OPERATION, SQL_REDO 
+          FROM V$LOGMNR_CONTENTS 
+          WHERE AND SCN > ${SCN:integer} 
+          AND OPERATION in ('INSERT', 'DELETE', 'UPDATE')
+    startupTasks:
+      - type: pull
+        dataSource: db
+        startFromLastReadRow: true
+        initParameters:
+          SCN:
+            - "-1"
+        beforeUpdateQueryIds:
+          - add-logfile-1
+          - add-logfile-2
+          - add-logfile-3
+          - start-log-miner
+        updateQueryId: update-logmnr-contents
+        afterUpdateQueryIds:
+          - end-log-miner
+        useColumns:
+          - SCN
+        interval: 1000
+    publication:
+      queueSize: 1000
+      maxDelayMillis: 1000
+      maxBatchSize: 100
+    eventPublication:
+      maxBatchSizeInBytes: 1048576
+      maxBatchSizeInItems: 100
+      maxFlushTime: 1000
+    useTransport: true
+  pins:
+    mq:
+      publishers:
+        - name: store
+          attributes: ['transport-group', 'publish', 'store']
+    grpc:
+      client:
+        - name: to_data_provider
+          serviceClass: com.exactpro.th2.dataprovider.lw.grpc.DataProviderService
+          linkTo:
+            - box: lw-data-provider
+              pin: server
+      server:
+        - name: server
+          serviceClasses:
+            - com.exactpro.th2.read.db.grpc.ReadDbService
+            - th2.read_db.ReadDbService
+  extendedSettings:
+    service:
+      enabled: false
+    envVariables:
+      JAVA_TOOL_OPTIONS: "-XX:+ExitOnOutOfMemoryError"
+    resources:
+      limits:
+        memory: 500Mi
+        cpu: 600m
+      requests:
+        memory: 100Mi
+        cpu: 50m
+```


### PR DESCRIPTION
… and puts it into related event and messages.