### PR TITLE
add if condition because failure of previous tasks are propagated

### DIFF
--- a/.github/workflows/build-dev-release.yml
+++ b/.github/workflows/build-dev-release.yml
@@ -113,9 +113,7 @@ jobs:
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.SONATYPE_GPG_ARMORED_KEY }}
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.SONATYPE_SIGNING_PASSWORD }}
   owasp-scan:
-    if: needs.build-and-publish-core-java.result == 'success' && !cancelled()
-    needs:
-      - build-and-publish-core-java
+    if: "!cancelled()"
     uses: th2-net/.github/.github/workflows/owasp-gradle-scan.yml@main
     with:
       multiproject: true

--- a/.github/workflows/build-dev-release.yml
+++ b/.github/workflows/build-dev-release.yml
@@ -95,9 +95,7 @@ jobs:
     needs:
       - build-and-publish-grpc-java
       - changes
-    if: |
-      always() &&
-      (needs.changes.outputs.core == 'true' || needs.changes.outputs.grpc == 'true')
+    if: (needs.changes.outputs.core == 'true' || needs.changes.outputs.grpc == 'true') && !cancelled()
     steps:
       - uses: actions/checkout@v3
       - name: Set up JDK 'zulu' '11'
@@ -115,6 +113,7 @@ jobs:
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.SONATYPE_GPG_ARMORED_KEY }}
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.SONATYPE_SIGNING_PASSWORD }}
   owasp-scan:
+    if: needs.build-and-publish-core-java.result == 'success' && !cancelled()
     needs:
       - build-and-publish-core-java
     uses: th2-net/.github/.github/workflows/owasp-gradle-scan.yml@main
@@ -129,8 +128,8 @@ jobs:
       - app-version
       - changes
     if: |
-      always() &&
       (needs.changes.outputs.app == 'true' || needs.changes.outputs.grpc == 'true' || needs.changes.outputs.core == 'true')
+      && !cancelled()
     uses: th2-net/.github/.github/workflows/compaund-java-docker-push.yml@main
     with:
       docker-username: ${{ github.actor }}
@@ -143,6 +142,7 @@ jobs:
       docker-password: ${{ secrets.GITHUB_TOKEN }}
   trivy-docker-scan:
     name: Scan Docker image for vulnerabilities
+    if: needs.publish-docker.result == 'success' && !cancelled()
     needs:
       - publish-docker
       - app-version

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -73,9 +73,7 @@ jobs:
       sonatypeSigningKey: ${{ secrets.SONATYPE_GPG_ARMORED_KEY }}
       sonatypeSigningPassword: ${{ secrets.SONATYPE_SIGNING_PASSWORD }}
   owasp-scan:
-    if: needs.build-and-publish-core-java.result == 'success' && !cancelled()
-    needs:
-      - build-and-publish-core-java
+    if: "!cancelled()"
     uses: th2-net/.github/.github/workflows/owasp-gradle-scan.yml@main
     with:
       multiproject: true

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -61,7 +61,7 @@ jobs:
     needs:
       - changes
       - build-and-publish-grpc-java
-    if: ${{ needs.changes.outputs.core == 'true' }}
+    if: (needs.changes.outputs.core == 'true' || needs.changes.outputs.grpc == 'true') && !cancelled()
     uses: th2-net/.github/.github/workflows/compaund-java-multi-project-build-release.yml@main
     with:
       projectPath: core
@@ -73,6 +73,7 @@ jobs:
       sonatypeSigningKey: ${{ secrets.SONATYPE_GPG_ARMORED_KEY }}
       sonatypeSigningPassword: ${{ secrets.SONATYPE_SIGNING_PASSWORD }}
   owasp-scan:
+    if: needs.build-and-publish-core-java.result == 'success' && !cancelled()
     needs:
       - build-and-publish-core-java
     uses: th2-net/.github/.github/workflows/owasp-gradle-scan.yml@main
@@ -83,8 +84,8 @@ jobs:
   publish-docker:
     name: Build and publish docker image
     if: |
-      always() &&
       (needs.changes.outputs.app == 'true' || needs.changes.outputs.grpc == 'true' || needs.changes.outputs.core == 'true')
+      && !cancelled()
     needs:
       - build-and-publish-grpc-python
       - build-and-publish-grpc-java
@@ -102,6 +103,7 @@ jobs:
       docker-password: ${{ secrets.GITHUB_TOKEN }}
   trivy-docker-scan:
     name: Scan Docker image for vulnerabilities
+    if: needs.publish-docker.result == 'success' && !cancelled()
     needs:
       - publish-docker
       - app-version

--- a/.github/workflows/build-sanpshot.yml
+++ b/.github/workflows/build-sanpshot.yml
@@ -55,8 +55,7 @@ jobs:
       sonatypeSigningKey: ${{ secrets.SONATYPE_GPG_ARMORED_KEY }}
       sonatypeSigningPassword: ${{ secrets.SONATYPE_SIGNING_PASSWORD }}
   owasp-scan:
-    needs:
-      - build-and-publish-core-java
+    if: "!cancelled()"
     uses: th2-net/.github/.github/workflows/owasp-gradle-scan.yml@main
     with:
       multiproject: true


### PR DESCRIPTION
This change was created because owasp stage was skipped after failure java grpc stage.
https://github.com/th2-net/th2-read-db/actions/runs/8374183781

stage failure status is propagated to the whole nest stages
https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idneeds
