### PR TITLE
Correct pattern in branches to match dependabot's branches as well

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -3,7 +3,7 @@ name: "Run integration tests for read-db"
 on:
   push:
     branches:
-      - '*'
+      - '**'
 
 jobs:
   tests:


### PR DESCRIPTION
Original pattern `*` does not match `/` according to the [official documentation](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet). We should use `**` instead